### PR TITLE
mjs to module.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Khaled Garbaya <kgarbaya@gmail.com>",
   "license": "MIT",
   "source": "src/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/index.module.js",
   "unpkg": "dist/index.umd.js",
   "scripts": {
     "build": "microbundle",


### PR DESCRIPTION
This PR moves back to .js files. It reduces friction with webpack which doesn't resolve .mjs the same way as .js thus breaking imports in submodules. 